### PR TITLE
[ME-3978] Add Support for Kotlin Generation

### DIFF
--- a/Dockerfile.kotlin
+++ b/Dockerfile.kotlin
@@ -1,0 +1,40 @@
+FROM ubuntu:24.04
+
+# Set the default shell to bash
+SHELL ["/bin/bash", "-c"]
+
+# Update and install necessary packages
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    zip \
+    openjdk-17-jdk \
+    protobuf-compiler
+
+WORKDIR /app
+
+# Install protoc-gen-grpc-kotlin, track versions in
+# https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/
+RUN curl -s https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.4.1/protoc-gen-grpc-kotlin-1.4.1-jdk8.jar -o /usr/local/bin/protoc-gen-grpc-kotlin.jar
+
+# Need to create an executable wrapper for the Jar for use with protoc
+RUN echo '#!/bin/bash' > /usr/local/bin/protoc-gen-grpc-kotlin.sh && \
+    echo 'java -jar /usr/local/bin/protoc-gen-grpc-kotlin.jar "$@"' >> /usr/local/bin/protoc-gen-grpc-kotlin.sh && \
+    chmod +x /usr/local/bin/protoc-gen-grpc-kotlin.sh
+
+# Need to download well-known protobuf types (e.g., timestamp, struct, etc.)
+RUN git clone https://github.com/protocolbuffers/protobuf.git && \
+    mkdir -p /usr/include && \
+    cp -r protobuf/src/* /usr/include/ && \
+    rm -rf protobuf
+
+VOLUME /app/gen
+
+ENTRYPOINT mkdir -p /app/gen/kotlin && protoc \
+    -I/app/proto \
+    -I/app/shared \
+    --plugin=protoc-gen-kotlin_grpc=/usr/local/bin/protoc-gen-grpc-kotlin.sh \
+    --kotlin_out=/app/gen/kotlin \
+    --kotlin_grpc_out=/app/gen/kotlin \
+    /app/proto/*.proto

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lang?=go
 # add any components here after their directory has been created with .proto files
 COMPONENTS:=common connector device 
 
-all: go swift
+all: go swift kotlin
 
 go:
 	make docker-run lang=go
@@ -14,8 +14,11 @@ go:
 swift:
 	make docker-run lang=swift
 
+kotlin:
+	make docker-run lang=kotlin
+
 docker-run: docker-build
-	$(foreach component, $(COMPONENTS), docker run -v $(PWD)/common:/app/shared/common -v $(PWD)/$(component):/app/proto $(NAME)-builder-$(lang);)
+	$(foreach component, $(COMPONENTS), docker run -v $(PWD)/common:/app/shared/common -v $(PWD)/$(component):/app/proto -v $(PWD)/gen:/app/gen $(NAME)-builder-$(lang);)
 
 docker-build:
 	docker build -f Dockerfile.$(lang) -t $(NAME)-builder-$(lang) .


### PR DESCRIPTION
## [[ME-3978](https://mysocket.atlassian.net/browse/ME-3978)] Add Support for Kotlin Generation

`make kotlin` or `make` will build for kotlin and dump the output in /gen/kotlin e.g.:

```
14:12 $ make kotlin
make docker-run lang=kotlin
docker build -f Dockerfile.kotlin -t border0-proto-builder-kotlin .
[+] Building 0.4s (10/10) FINISHED                                                                                                                                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile.kotlin                                                                                                                                                      0.0s
 => => transferring dockerfile: 1.43kB                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                                                  0.4s
 => [internal] load .dockerignore                                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                                  0.0s
 => [1/6] FROM docker.io/library/ubuntu:24.04@sha256:80dd3c3b9c6cecb9f1667e9290b3bc61b78c2678c02cbdae5f0fea92cc6734ab                                                                                            0.0s
 => CACHED [2/6] RUN apt-get update && apt-get install -y     build-essential     curl     git     zip     openjdk-17-jdk     protobuf-compiler                                                                  0.0s
 => CACHED [3/6] WORKDIR /app                                                                                                                                                                                    0.0s
 => CACHED [4/6] RUN curl -s https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-kotlin/1.4.1/protoc-gen-grpc-kotlin-1.4.1-jdk8.jar -o /usr/local/bin/protoc-gen-grpc-kotlin.jar                              0.0s
 => CACHED [5/6] RUN echo '#!/bin/bash' > /usr/local/bin/protoc-gen-grpc-kotlin.sh &&     echo 'java -jar /usr/local/bin/protoc-gen-grpc-kotlin.jar "$@"' >> /usr/local/bin/protoc-gen-grpc-kotlin.sh &&     ch  0.0s
 => CACHED [6/6] RUN git clone https://github.com/protocolbuffers/protobuf.git &&     mkdir -p /usr/include &&     cp -r protobuf/src/* /usr/include/ &&     rm -rf protobuf                                     0.0s
 => exporting to image                                                                                                                                                                                           0.0s
 => => exporting layers                                                                                                                                                                                          0.0s
 => => writing image sha256:4af3f198b732952a209df7a49168f6705fa5fc7a7a0daf8285c593190472c0e6                                                                                                                     0.0s
 => => naming to docker.io/library/border0-proto-builder-kotlin                                                                                                                                                  0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/ktj7op6trk0mgh9eums6rkftl
docker run -v /Users/adriano/go/src/github.com/borderzero/border0-proto/common:/app/shared/common -v /Users/adriano/go/src/github.com/borderzero/border0-proto/common:/app/proto -v /Users/adriano/go/src/github.com/borderzero/border0-proto/gen:/app/gen border0-proto-builder-kotlin;  docker run -v /Users/adriano/go/src/github.com/borderzero/border0-proto/common:/app/shared/common -v /Users/adriano/go/src/github.com/borderzero/border0-proto/connector:/app/proto -v /Users/adriano/go/src/github.com/borderzero/border0-proto/gen:/app/gen border0-proto-builder-kotlin;  docker run -v /Users/adriano/go/src/github.com/borderzero/border0-proto/common:/app/shared/common -v /Users/adriano/go/src/github.com/borderzero/border0-proto/device:/app/proto -v /Users/adriano/go/src/github.com/borderzero/border0-proto/gen:/app/gen border0-proto-builder-kotlin;
✔ ~/go/src/github.com/borderzero/border0-proto [ME-3978_add_support_for_kotlin_gen|…54]
14:12 $ tree gen/
gen/
└── kotlin
    └── border0
        ├── common
        │   └── v1
        │       ├── DisconnectMessageKt.kt
        │       ├── DiscoveryDetailsMessageKt.kt
        │       ├── HeartbeatMessageKt.kt
        │       ├── MessagesKt.kt
        │       ├── NetworkDeviceStatsMessageKt.kt
        │       ├── NetworkStateMessageKt.kt
        │       ├── PeerOfflineMessageKt.kt
        │       ├── PeerOnlineMessageKt.kt
        │       ├── ServiceKt.kt
        │       ├── StatsMessageKt.kt
        │       └── WireGuardPeerKt.kt
        ├── device
        │   └── v1
        │       ├── AuthChallengeMessageKt.kt
        │       ├── AuthChallengeSolutionMessageKt.kt
        │       ├── DeviceGrpcKt.kt
        │       ├── DeviceKt.kt
        │       ├── DeviceToServerMessageKt.kt
        │       ├── ServerToDeviceMessageKt.kt
        │       └── ServiceKt.kt
        └── v1
            ├── AuthorizePeerRequestKt.kt
            ├── AuthorizeRequestKt.kt
            ├── AuthorizeResponseKt.kt
            ├── CertificateSignRequestKt.kt
            ├── CertificateSignResponseKt.kt
            ├── ConfigKt.kt
            ├── ConnectorConfigKt.kt
            ├── ConnectorGrpcKt.kt
            ├── ConnectorKt.kt
            ├── ConnectorMetadataKt.kt
            ├── ControlStreamRequestKt.kt
            ├── ControlStreamResponseKt.kt
            ├── DisconnectKt.kt
            ├── DiscoverKt.kt
            ├── InitKt.kt
            ├── LogKt.kt
            ├── OrganizationKt.kt
            ├── PermissionsKt.kt
            ├── PluginConfigKt.kt
            ├── PluginDiscoveryResultsKt.kt
            ├── PluginDiscoveryResultsMetadataKt.kt
            ├── SessionEventKt.kt
            ├── SessionRequestKt.kt
            ├── SessionResponseKt.kt
            ├── SessionUpdateRequestKt.kt
            ├── SocketConfigKt.kt
            ├── SshCertificateSignRequestKt.kt
            ├── SshCertificateSignResponseKt.kt
            ├── StopKt.kt
            ├── TagKt.kt
            ├── TunnelCertificateSignRequestKt.kt
            ├── TunnelCertificateSignResponseKt.kt
            ├── UpdateConfigKt.kt
            ├── UploadRecordingKt.kt
            ├── actionListKt.kt
            └── infoListKt.kt

8 directories, 54 files
```

[ME-3978]: https://mysocket.atlassian.net/browse/ME-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ